### PR TITLE
Fix tests and token detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-username = hpe-csi
 csp = http://localhost:8080
 curl = curl
-curl_args = '-v'
+curl_args = -v
+
+ifndef username
+	username = hpe-csi
+endif
+
+ifeq ($(username), root)
+	auth := Authorization: Bearer $(username):$(password)
+else
+	auth = X-Auth-Token: $(password)
+endif
 
 all:
 	python3 -m py_compile truenascsp/*.py

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,7 @@
+username = hpe-csi
 csp = http://localhost:8080
 curl = curl
-curl_args = -v
-
-ifndef username
-	username = hpe-csi
-endif
-
-ifeq ($(username), root)
-	auth := Authorization: Bearer $(username):$(password)
-else
-	auth = X-Auth-Token: $(password)
-endif
+curl_args = '-v'
 
 all:
 	python3 -m py_compile truenascsp/*.py


### PR DESCRIPTION
Thanks for this PR and apologize the delay. I made some changes. I did not quite like the 'root:admin' password syntax and instead added API key detection with a regex. This is of course not 100% foolproof is someone's password starts with number and a hyphen (i.e 0-MyPassword) but I'll add it to the docs for the release.

Signed-off-by: datamattsson <michael.mattsson@gmail.com>